### PR TITLE
ci(gh-pages): fix workdir with repo name

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -29,14 +29,12 @@ jobs:
         with:
           node-version: 22
           cache: 'npm'
-          cache-dependency-path: frontend/package-lock.json
+          cache-dependency-path: package-lock.json
 
       - name: Install dependencies
-        working-directory: frontend
         run: npm ci
 
       - name: Build Vite project
-        working-directory: frontend
         # env:
         #   VITE_: ${{ secrets.VITE_ }}
         run: npm run build
@@ -47,7 +45,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: './frontend/dist'
+          path: './dist'
 
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           node-version: 22
           cache: 'npm'
-          cache-dependency-path: package-lock.json
+          cache-dependency-path: ./package-lock.json
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Description

Fix useless gitlab mention to repo name as work directory on actions

## Type of Change

<!-- Check all that apply -->
- [ ] New feature
- [x] Bug fix
- [ ] Chore
- [ ] Tests
- [ ] Documentation
- [x] CI Change
- [ ] Performance Improvement
- [ ] Refactor
- [ ] Build may be affected

## Removed

- [ ] Useless workdir with repo name on ci

## Checklist

- [x] Branch follows the [naming conventions](../CONTRIBUTING.md#branch-naming-conventions)
- [x] Code follows style guidelines
- [ ] Tests added or updated
- [x] All tests pass locally
- [ ] Documentation updated (if needed)
