### PR TITLE
Chore - fix pages basepath

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
 VITE_API_URL=http://localhost:3000
 
-CYPRESS_BASE_URL=http://localhost:5173
+CYPRESS_BASE_URL=http://localhost:5173/frontend
 CYPRESS_USE_MOCK_API_DATA=false

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Cypress Run
         uses: cypress-io/github-action@v6
         env:
-          CYPRESS_BASE_URL: http://localhost:4173
+          CYPRESS_BASE_URL: http://localhost:4173/frontend
           CYPRESS_USE_MOCK_API_DATA: true
         with:
           start: npm run preview

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ dev-dist
 # Testing
 
 cypress/downloads
+cypress/screenshots

--- a/src/routes/AppRouter.tsx
+++ b/src/routes/AppRouter.tsx
@@ -6,7 +6,7 @@ import TechDemoMockAPI from '../pages/TechDemo/MockAPI.tsx';
 
 function AppRouter() {
   return (
-    <BrowserRouter basename='/'>
+    <BrowserRouter basename='/frontend/'>
       <Routes>
         <Route index element={<Home />} />
         <Route path="tech-demo" element={<TechDemo />}>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,7 +4,7 @@ import { VitePWA } from 'vite-plugin-pwa';
 
 // https://vite.dev/config/
 export default defineConfig({
-  base: '/',
+  base: '/frontend/',
   plugins: [react(), VitePWA({
     devOptions: { enabled: true },
     manifest: {


### PR DESCRIPTION
## Description

GitHub pages expects code to be inside /reponame (so /frontend) for pages build artifacts

## Type of Change

<!-- Check all that apply -->
- [ ] New feature
- [x] Bug fix
- [x] Chore
- [ ] Tests
- [ ] Documentation
- [x] CI Change
- [ ] Performance Improvement
- [ ] Refactor
- [x] Build may be affected

## Changed

- [ ] Base path from '/' to '/frontend'

## Checklist

- [x] Branch follows the [naming conventions](../CONTRIBUTING.md#branch-naming-conventions)
- [x] Code follows style guidelines
- [x] Tests added or updated
- [x] All tests pass locally
- [ ] Documentation updated (if needed)
